### PR TITLE
Explicity set status code with `res.status().send()`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 .tmp
 .sass-cache
 *.log
+.test*

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -40,7 +40,7 @@ module.exports = function (host, options) {
 
 // construct the async waterfall stream
 //
-// acccept
+// accept
 // buildStream(host)
 //      OR
 // buildStream(host, secureBool)
@@ -263,7 +263,7 @@ function respond (next) {
       return next(new Error('Proxy to ' + proxyObj.reqOpts.url + ' failed for an unkown reason'));
 
     } else {
-      proxyObj.res.send(proxyObj.result.body);
+      proxyObj.res.status(proxyObj.result.response.statusCode || 400).send(proxyObj.result.body);
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "proxy-express",
   "author": "John Hofrichter <https://github.com/johnhof>",
   "description": "Request proxying middleware for express",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "repository": "git://github.com/johnhof/proxy-express",
   "main": "lib/proxy.js",
   "keywords": [

--- a/test/core_unit_tests.js
+++ b/test/core_unit_tests.js
@@ -88,7 +88,7 @@ String.prototype.toUrl = function () {
 ////////////////////////////////////////////////////////////
 
 
-describe('Core Unit tests', function () {
+describe('Core Unit Tests', function () {
   describe('Config Options', function () {
 
 

--- a/test/regression_tests.js
+++ b/test/regression_tests.js
@@ -6,14 +6,14 @@ var expect     = require('chai').expect;
 
 ////////////////////////////////////////////////////////////
 //
-// Integration tests
+// Regression tests
 //
 ////////////////////////////////////////////////////////////
 
 
-describe('Core Integration Tests', function () {
-  describe('Smoke test', function () {
-    it('should make a basic request to github', function (done) {
+describe('Regression Tests', function () {
+  describe('Status Code', function () {
+    it('should properly proxy non 200 responses', function (done) {
       var server = express();
 
       server.use(proxy('api.github.com', {
@@ -26,7 +26,7 @@ describe('Core Integration Tests', function () {
         }
       }));
 
-      superTest(server).get('/github').expect(200).end(done);
+      superTest(server).get('/github/four/oh/four').expect(404).end(done);
     })
   });
 });


### PR DESCRIPTION
Fix for https://github.com/johnhof/proxy-express/issues/15

@logankoester take a look if you like. I'll merge later today after the build passes if you dont have time.
