### PR TITLE
added support for filter functions and the strictSSL request option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@ dist
 .tmp
 .sass-cache
 *.log
+/proxy-express.iml
+/.idea
 .test*

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,4 +1,5 @@
-var _ = require('lodash')
+var _ = require('lodash');
+var URL = require('url');
 
 // Default Headers
 //
@@ -19,23 +20,30 @@ exports.defaultHeaders = function (overrideObj, defaultObj) {
   });
 
   return result;
-}
+};
 
 // Matches Filter
 //
-// test a filter against a path. Accepts regex and substring
+// test a filter against a request. Accepts regex, substring, or a function returning a boolean, regex or substring
 //
-exports.matchesRestriction = function (path, filter) {
+exports.matchesRestriction = function (req, filter) {
+  while(_.isFunction(filter)) {
+    filter = filter(req); // a filter function can return a boolean, a regexp, a string or another function
+  }
+
+  if(_.isBoolean( filter )) return filter;
+
+  var reqUrlPath = URL.parse(req.url).path;
   // if the filter is a regex and it matched the path
   if (_.isRegExp(filter)) {
-    return filter.test(path);
+    return filter.test(reqUrlPath);
+  }
 
   // if the filter is a string and its contained in the path
-  } else if (_.isString(filter)) {
-    return path.indexOf(filter) !== -1;
-
-    // if the filter isn't valid, return true
-  } else {
-    return true;
+  if (_.isString(filter)) {
+    return reqUrlPath.indexOf(filter) !== -1;
   }
-}
+
+  // if the filter isn't valid, return true
+  return true;
+};

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -173,7 +173,7 @@ function buildResultingMiddleware (host, options, sharedStream) {
       url     :  URL.format(proxyUrl),
       method  : req.method,
       form    : _.defaults(options.request.form, req.body),
-      qs      : _.defaults(options.request.query, req.query),
+      qs      : _.defaults({},options.request.query, req.query),
       headers : helpers.defaultHeaders(options.request.headers, req.headers),
       encoding: encoding,
       followAllRedirects : options.request.followRedirects !== false ? true : false,

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -20,6 +20,7 @@ module.exports = function (host, options) {
     };
 
   } else if (typeof options === 'RegExp') {
+    // @todo typeof options will be 'object' if it's a RegExp; check with _.isRegExp()
     options = {
       restrict : {
         match : options
@@ -30,7 +31,7 @@ module.exports = function (host, options) {
   var stream = buildStream(host, options);
 
   return buildResultingMiddleware(host, options, stream);
-}
+};
 
 ////////////////////////////////////////////////////////////
 //
@@ -117,7 +118,7 @@ function buildResultingMiddleware (host, options, sharedStream) {
       pathname : reqUrl.pathname,
       protocol : options.request.forceHttps ? 'https' : req.protocol,
       host     : host
-    }
+    };
 
     //
     // Check user defined proxy conditions
@@ -146,22 +147,11 @@ function buildResultingMiddleware (host, options, sharedStream) {
 
     // if there are restricts applied, and we havent failed out yet
     if (options.restrict && shouldProxy) {
-      // if its a lone restrict, and it doesnt match the url
-      if (_.isRegExp(options.restrict) || _.isString(options.restrict)) {
-        shouldProxy = helpers.matchesRestriction(reqUrl.path, options.restrict);
 
-      // if its an array of restricts
-      } else if (_.isArray(options.restrict)) {
-        var passedOne = false;
-        _.each(options.restrict, function (restriction) {
-          if (helpers.matchesRestriction(reqUrl.path, restriction)) {
-            passedOne = true;
-            return false; // exit the loop
-          }
-        });
-
-        shouldProxy = passedOne;
-      }
+      shouldProxy = !!_.find(
+          _.isArray(options.restrict) ? options.restrict : [options.restrict],
+          helpers.matchesRestriction.bind(helpers,req)
+      );
     }
 
     // if the current route isn't greenlit for the passthrough, bail out
@@ -186,7 +176,8 @@ function buildResultingMiddleware (host, options, sharedStream) {
       qs      : _.defaults(options.request.query, req.query),
       headers : helpers.defaultHeaders(options.request.headers, req.headers),
       encoding: encoding,
-      followAllRedirects : options.request.followRedirects !== false ? true : false
+      followAllRedirects : options.request.followRedirects !== false ? true : false,
+      strictSSL: options.request.strictSSL !== undefined ? options.request.strictSSL : true
     };
 
     // if the route is greenlit, add the proxy option builder to the stream
@@ -217,7 +208,7 @@ function buildResultingMiddleware (host, options, sharedStream) {
 // async function to make the proxied request (fires between brefore `pre` and `post` functions)
 //
 function proxyReq (proxyObj, callback) {
-  var proxyError = proxyObjErrors(proxyObj)
+  var proxyError = proxyObjErrors(proxyObj);
   if (proxyError) { return callback(new Error(proxyError)); }
 
   if (proxyObj.options.log) { logReqOpts(proxyObj.reqOpts) }
@@ -262,7 +253,7 @@ function respond (next) {
       });
     }
 
-    var proxyError = proxyObjErrors(proxyObj)
+    var proxyError = proxyObjErrors(proxyObj);
     if (proxyError) {
       return next(new Error(proxyError));
 

--- a/test/core_integration_tests.js
+++ b/test/core_integration_tests.js
@@ -22,7 +22,8 @@ describe('Core Integration Tests', function () {
           forceHttps : true,
           strictSSL  : false,
           headers    : {
-            'User-Agent' : 'Mozilla/5.0 (X11; Linux i686 (x86_64)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.71 Safari/537.36'
+            'User-Agent' : 'Mozilla/5.0 (X11; Linux i686 (x86_64)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.71 Safari/537.36',
+            Authorization : require('./github_auth_header')
           }
         }
       }));

--- a/test/core_integration_tests.js
+++ b/test/core_integration_tests.js
@@ -20,8 +20,9 @@ describe('Core Integration Tests', function () {
         prefix  : 'github',
         request : {
           forceHttps : true,
+          strictSSL  : false,
           headers    : {
-            'User-Agent' : 'Mozilla/5.0 (X11; Linux i686 (x86_64)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.71 Safari/537.36',
+            'User-Agent' : 'Mozilla/5.0 (X11; Linux i686 (x86_64)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.71 Safari/537.36'
           }
         }
       }));

--- a/test/core_unit_tests.js
+++ b/test/core_unit_tests.js
@@ -36,7 +36,7 @@ function testProxyConfig (options, finalCb) {
   // set up some defaults so we dont need to worry later
   options                     = options || {};
   options.request             = options.request || {};
-  options.request.headers     = options.request.headers || {};
+  options.request.headers     = _.defaults({},options.request.headers || {},{Authorization:require('./github_auth_header')}),
   options.request.query       = options.request.query || {};
   options.request.form        = options.request.form || {};
   options.request.method      = (options.request.method || 'GET').toLowerCase()

--- a/test/github_auth_header.js
+++ b/test/github_auth_header.js
@@ -1,0 +1,1 @@
+module.exports = 'token 204136142daaee520caee82245cf7951ec62b0b4';

--- a/test/helpers_unit_tests.js
+++ b/test/helpers_unit_tests.js
@@ -1,7 +1,7 @@
 var helpers = require('../lib/helpers');
 var mocha   = require('mocha');
 var expect  = require('chai').expect;
-
+var _       = require('lodash');
 
 ////////////////////////////////////////////////////////////
 //
@@ -27,7 +27,7 @@ describe('Helpers Unit Tests', function () {
 
     it('should override existing headers', function () {
       expect(result.foo).to.equal(success)
-    })
+    });
 
     it('should preserve headers not explicitly overridden', function () {
       expect(result.baz).to.equal(success)
@@ -41,23 +41,72 @@ describe('Helpers Unit Tests', function () {
   // Matches Restriction
   //
   describe('matchesRestriction', function () {
-    var regExp = /.+\/bar/
-    var string = 'foo'
+    var regExp = /.+\/bar/;
+    var string = 'foo';
 
     it('should return true for path matching regex', function () {
-      expect(helpers.matchesRestriction('/foo/bar', regExp)).to.equal(true);
+      expect(helpers.matchesRestriction({url:'/foo/bar'}, regExp)).to.equal(true);
     });
 
     it('should return false for path failing to match regexp', function () {
-      expect(helpers.matchesRestriction('/bar/foo', regExp)).to.equal(false);
+      expect(helpers.matchesRestriction({url:'/bar/foo'}, regExp)).to.equal(false);
     });
 
     it('should return true for path containing string', function () {
-      expect(helpers.matchesRestriction('/foo/bar', string)).to.equal(true);
+      expect(helpers.matchesRestriction({url:'/foo/bar'}, string)).to.equal(true);
     });
 
     it('should return false for path containing string', function () {
-      expect(helpers.matchesRestriction('/bar/biz', string)).to.equal(false);
+      expect(helpers.matchesRestriction({url:'/bar/biz'}, string)).to.equal(false);
+    });
+
+    describe('with a filter function', function () {
+      describe('returning boolean', function(){
+        it('should return false for a function that returns false', function() {
+          expect(helpers.matchesRestriction({url:'/bar/biz'}, function(){ return false; })).to.equal(false);
+        });
+
+        it('should return true for a function that returns true', function() {
+          expect(helpers.matchesRestriction({url:'/bar/biz'}, function(){ return true; })).to.equal(true);
+        });
+      });
+
+      describe('returning a string', function(){
+        it('should return true for a path containing a string', function() {
+          expect(helpers.matchesRestriction({url:'/foo/bar'}, function(){ return string; })).to.equal(true);
+        });
+
+        it('should return false for a path containing string', function () {
+          expect(helpers.matchesRestriction({url:'/bar/biz'}, function(){ return string; })).to.equal(false);
+        });
+      });
+
+      describe('returning a regexp', function(){
+        it('should return true for path matching regex', function () {
+          expect(helpers.matchesRestriction({url:'/foo/bar'}, function(){ return regExp; })).to.equal(true);
+        });
+
+        it('should return false for path failing to match regexp', function () {
+          expect(helpers.matchesRestriction({url:'/bar/foo'}, function(){ return regExp; })).to.equal(false);
+        });
+      });
+
+      describe('returning a function', function() {
+        describe('returning boolean', function () {
+          it('should return false for a function that returns false', function () {
+            expect(helpers.matchesRestriction({url: '/bar/biz'}, function () {
+              return _.constant(false);
+            })).to.equal(false);
+          });
+
+          it('should return true for a function that returns true', function () {
+            expect(helpers.matchesRestriction({url: '/bar/biz'}, function () {
+              return _.constant(true);
+            })).to.equal(true);
+          });
+        });
+      });
+
     });
   });
 });

--- a/test/regression_tests.js
+++ b/test/regression_tests.js
@@ -22,7 +22,8 @@ describe('Regression Tests', function () {
           forceHttps : true,
           strictSSL  : false,
           headers    : {
-            'User-Agent' : 'Mozilla/5.0 (X11; Linux i686 (x86_64)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.71 Safari/537.36'
+            'User-Agent' : 'Mozilla/5.0 (X11; Linux i686 (x86_64)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.71 Safari/537.36',
+            Authorization : require('./github_auth_header')
           }
         }
       }));

--- a/test/regression_tests.js
+++ b/test/regression_tests.js
@@ -20,8 +20,9 @@ describe('Regression Tests', function () {
         prefix  : 'github',
         request : {
           forceHttps : true,
+          strictSSL  : false,
           headers    : {
-            'User-Agent' : 'Mozilla/5.0 (X11; Linux i686 (x86_64)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.71 Safari/537.36',
+            'User-Agent' : 'Mozilla/5.0 (X11; Linux i686 (x86_64)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.71 Safari/537.36'
           }
         }
       }));


### PR DESCRIPTION
Hi there!
Thank you for this wonderful package!

I've added two new options, `strictSSL` and filter functions. I hope you like the changes!
## strictSSL

We're using proxy-express in an enterprise environment behind a proxy, where SSL only works with the `strictSSL` option turned off; I added this as an option.
## Filter Functions

We needed `restrictions` to trigger when a certain header is set; to do that without introducing much complexity, I added an additional filter type, `function`.  A filter function can return a boolean, string, a Regexp or another filter function. So whenever someone needs some more logic than String or Regexp, the filter function 
