### PR TITLE
Arrays in `matchesRestriction`, updated docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,17 +126,21 @@ proxy('www.foo.com', {
   // /biz/bar => proxied
   // /biz => ignored
 });
+```
 
 // OR
 
+```javascript
 proxy('www.foo.com', {
   restrict : /\/bar$/
   // /biz/bar => proxied
   // /bar/biz => ignored
 });
+```
 
 // OR
 
+```javascript
 proxy('www.foo.com', {
   restrict : [/\/bar$/, 'foo']
   // /biz/bar => proxied
@@ -147,6 +151,7 @@ proxy('www.foo.com', {
 
 // OR
 
+```javascript
 proxy('www.foo.com', {
   restrict : function(req){
     return req.get('force-proxy') !=== undefined

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This module is designed to simplify server logic when utilizing 3rd party API's.
     - [.restrict](#restrict)
     - [.request](#request)
         - [.forceHttps](#forcehttps)
+        - [.strictSSL](#strictssl)
         - [.prepend](#prepend)
         - [.followRedirects](#followredirects)
         - [.headers](#headers)
@@ -115,7 +116,7 @@ proxy('www.foo.com', {
 
 ## .restrict
 
-Type : `String || RegExp || Array`
+Type : `String || RegExp || Array || Function`
 
 Only routes matching the restrictions will be run through the proxy
 
@@ -144,6 +145,17 @@ proxy('www.foo.com', {
 });
 ```
 
+// OR
+
+proxy('www.foo.com', {
+  restrict : function(req){
+    return req.get('force-proxy') !=== undefined
+  }
+  // curl -H force-proxy:foobar http://127.0.0.1/anything
+  // => proxied
+});
+```
+
 ## .request
 
 Type: `Object`
@@ -160,6 +172,22 @@ If true, all requests to the proxied server will be made over https
 proxy('www.foo.com', {
   request : {
     forceHttps : true
+  }
+});
+```
+
+### .strictSSL
+
+Type: `Boolean`
+Default: `true`
+
+Whether or not to do SSL key validation when making requests to the registry via https.
+This is similar to the git/npm/request setting of the same name; useful if you're behind a proxy.
+
+```javascript
+proxy('www.foo.com', {
+  request : {
+    strictSSL : false
   }
 });
 ```

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -24,14 +24,25 @@ exports.defaultHeaders = function (overrideObj, defaultObj) {
 
 // Matches Filter
 //
-// test a filter against a request. Accepts regex, substring, or a function returning a boolean, regex or substring
+// test a filter against a request. Accepts
+// + RegExp   - returns true if RegExp.test matches req.url.path
+// + String   - returns true if req.url.path.find(String) > -1
+// + Boolean  - true if true, false if false
+// + Function returning any supported type (including Function)
+// + Array containing any any supported type (including Array)
 //
-exports.matchesRestriction = function (req, filter) {
+exports.matchesRestriction = function matchesRestriction(req, filter) {
   while(_.isFunction(filter)) {
-    filter = filter(req); // a filter function can return a boolean, a regexp, a string or another function
+    filter = filter(req);
   }
 
-  if(_.isBoolean( filter )) return filter;
+  if(_.isArray(filter)) {
+    return Boolean(_.find(filter,matchesRestriction.bind(req,req)));
+  }
+
+  if(_.isBoolean( filter )) {
+    return filter;
+  }
 
   var reqUrlPath = URL.parse(req.url).path;
   // if the filter is a regex and it matched the path

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -147,11 +147,7 @@ function buildResultingMiddleware (host, options, sharedStream) {
 
     // if there are restricts applied, and we havent failed out yet
     if (options.restrict && shouldProxy) {
-
-      shouldProxy = !Boolean(_.find(
-          _.isArray(options.restrict) ? options.restrict : [options.restrict],
-          helpers.matchesRestriction.bind(helpers,req)
-      ));
+      shouldProxy = helpers.matchesRestriction(req,options.restrict);
     }
 
     // if the current route isn't greenlit for the passthrough, bail out

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -148,10 +148,10 @@ function buildResultingMiddleware (host, options, sharedStream) {
     // if there are restricts applied, and we havent failed out yet
     if (options.restrict && shouldProxy) {
 
-      shouldProxy = !!_.find(
+      shouldProxy = !Boolean(_.find(
           _.isArray(options.restrict) ? options.restrict : [options.restrict],
           helpers.matchesRestriction.bind(helpers,req)
-      );
+      ));
     }
 
     // if the current route isn't greenlit for the passthrough, bail out

--- a/test/helpers_unit_tests.js
+++ b/test/helpers_unit_tests.js
@@ -107,6 +107,27 @@ describe('Helpers Unit Tests', function () {
         });
       });
 
+      describe('with an array', function () {
+        it('should return false if all array values return false', function() {
+          expect(helpers.matchesRestriction({url: '/bar/biz'}, [
+            regExp,
+            string,
+            false,
+            function () { return _.constant(false); }
+          ])).to.equal(false);
+        });
+
+        it('should return true if one array value returns true', function() {
+          expect(helpers.matchesRestriction({url: '/bar/biz'}, [
+            regExp,
+            string,
+            false,
+            function () { return _.constant(true); }
+          ])).to.equal(true);
+        });
+
+      });
+
     });
   });
 });


### PR DESCRIPTION
Hey there, me again :)

Minor update: `matchesRestriction` now handles arrays, so you can go weird with functions returning arrays containing functions and whatnot; the more serious use case is that whatever you pass into `matchesRestriction`, it will just always work correctly.

Also updated the docs so others can benefit from the changes.

Thanks :)
