### PR TITLE
Case insensitive image detection

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -155,7 +155,7 @@ function buildResultingMiddleware (host, options, sharedStream) {
 
     var encoding = undefined;
     //Handle Image Files
-    if (/jpe?g|gif|png|ico|bmp|tiff/.test(req.url)) {
+    if (/jpe?g|gif|png|ico|bmp|tiff/i.test(req.url)) {
       encoding = null;
     }
 


### PR DESCRIPTION
Proxied images with an extension in capital letters gets corrupted. So this little change makes the image detection case insensitive.
