### PR TITLE
Fixing Regex check so that it actually works 

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -19,7 +19,7 @@ module.exports = function (host, options) {
       prefix : options
     };
 
-  } else if (typeof options === 'RegExp') {
+  } else if (options instanceof RegExp) {
     // @todo typeof options will be 'object' if it's a RegExp; check with _.isRegExp()
     options = {
       restrict : {


### PR DESCRIPTION
Resolves #21 

Test in your console:

```
var one = /aaa/;
console.log(one instanceof RegExp) // true

var two = {opt: 'opt'};
console.log(two instanceof RegExp) // false

var three = new RegExp('aaab', 'g');
console.log(three instanceof RegExp) // true
```

:+1: http://stackoverflow.com/questions/4339288/typeof-for-regexp
