### PR TITLE
Updating To Node 4.4.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist
 /proxy-express.iml
 /.idea
 .test*
+/coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 before_install: npm install -g npm@latest
 node_js:
-  - "0.11"
-  - "0.10"
+  - "4.3.0"
+  - "5.6.0"

--- a/demo/server.js
+++ b/demo/server.js
@@ -1,12 +1,13 @@
-var server = require('express')();
-var proxy  = require('../lib/proxy');
-var bodyParser = require('body-parser');
+'use strict';
 
+const server = require('express')();
+const proxy  = require('../lib/proxy');
+const bodyParser = require('body-parser');
 
-server.use( bodyParser.json());       // to support JSON-encoded bodies
+server.use(bodyParser.json());       // to support JSON-encoded bodies
 server.use(bodyParser.urlencoded({     // to support URL-encoded bodies
   extended: true
-})); 
+}));
 
 // travis proxy
 server.use(proxy('api.travis-ci.org', {
@@ -43,7 +44,7 @@ server.use(proxy('i.imgur.com', {
 // simple server health check
 server.get('/status', function (req, res) {
   res.send('OK');
-})
+});
 
 // return the app for all other routes
 server.get('*', function (req, res) {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,12 +1,14 @@
-var _ = require('lodash');
-var URL = require('url');
+'use strict';
+
+const _ = require('lodash');
+const URL = require('url');
 
 // Default Headers
 //
 // defaults a flat object of headers. undefined deletes the header
 //
 exports.defaultHeaders = function (overrideObj, defaultObj) {
-  var result = defaultObj ? _.clone(defaultObj) : {};
+  let result = Object.assign({}, defaultObj);
 
   _.each(Object.keys(overrideObj || {}), function (key) {
     // delete anything explicitly set to undefined
@@ -31,16 +33,16 @@ exports.defaultHeaders = function (overrideObj, defaultObj) {
 // + Function returning any supported type (including Function)
 // + Array containing any any supported type (including Array)
 //
-exports.matchesRestriction = function matchesRestriction(req, filter) {
-  while(_.isFunction(filter)) {
+exports.matchesRestriction = function matchesRestriction (req, filter) {
+  while (_.isFunction(filter)) {
     filter = filter(req);
   }
 
-  if(_.isArray(filter)) {
-    return Boolean(_.find(filter,matchesRestriction.bind(req,req)));
+  if (_.isArray(filter)) {
+    return Boolean(_.find(filter, matchesRestriction.bind(req, req)));
   }
 
-  if(_.isBoolean( filter )) {
+  if (_.isBoolean(filter)) {
     return filter;
   }
 

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -1,9 +1,11 @@
-var request = require('request');
-var _       = require('lodash');
-var URL     = require('url');
-var async   = require('async');
-var colors  = require('colors');
-var helpers = require('./helpers');
+'use strict';
+
+const request = require('request');
+const _       = require('lodash');
+const URL     = require('url');
+const async   = require('async');
+const colors  = require('colors');
+const helpers = require('./helpers');
 
 ////////////////////////////////////////////////////////////
 //
@@ -15,20 +17,18 @@ module.exports = function (host, options) {
   if (typeof host !== 'string') { throw new Error('proxy-express expects `host` to be a string'); }
 
   if (typeof options === 'string') {
-    options =  {
-      prefix : options
-    };
-
-  } else if (options instanceof RegExp) {
-    // @todo typeof options will be 'object' if it's a RegExp; check with _.isRegExp()
     options = {
-      restrict : {
-        match : options
+      prefix: options
+    };
+  } else if (options instanceof RegExp) {
+    options = {
+      restrict: {
+        match: options
       }
     };
   }
 
-  var stream = buildStream(host, options);
+  let stream = buildStream(host, options);
 
   return buildResultingMiddleware(host, options, stream);
 };
@@ -70,16 +70,14 @@ function buildStream (host, options, secure) {
       if (_.isFunction(middleware)) {
         // wrapper allows us to call the callback without passing proxyObj
         stream.push(function asyncWrapper (proxyObj, callback) {
-          return middleware(proxyObj, function (error, _proxyObj) {
-            return callback(error, _proxyObj || proxyObj);
-          })
+          return middleware(proxyObj, (error, _proxyObj) => callback(error, _proxyObj || proxyObj));
         });
       }
     });
   }
 
   // if there is `pre` middleware
-  var preSet = options.pre;
+  let preSet = options.pre;
   if (preSet) {
     // accept raw functions, but wrap it in an array
     preSet = _.isFunction(preSet) ? [preSet] : preSet;
@@ -90,7 +88,7 @@ function buildStream (host, options, secure) {
   stream.push(proxyReq);
 
   // if there is `post` middleware
-  var postSet = options.post;
+  let postSet = options.post;
   if (postSet) {
     // accept raw functions, but wrap it in an array
     postSet = _.isFunction(postSet) ? [postSet] : postSet;
@@ -112,9 +110,9 @@ function buildStream (host, options, secure) {
 
 function buildResultingMiddleware (host, options, sharedStream) {
   return function proxyMiddleware (req, res, next) {
-    var stream = _.clone(sharedStream, true);
-    var reqUrl = URL.parse(req.url, true);
-    var proxyUrl  = {
+    let stream = _.clone(sharedStream, true);
+    let reqUrl = URL.parse(req.url, true);
+    let proxyUrl = {
       pathname : reqUrl.pathname,
       protocol : options.request.forceHttps ? 'https' : req.protocol,
       host     : host
@@ -128,7 +126,7 @@ function buildResultingMiddleware (host, options, sharedStream) {
 
     // If there is a prefix, it must match the route to continue
     if (typeof options.prefix === 'string') {
-      var prefix = options.prefix[0] == '/' ? options.prefix : '/' + options.prefix;
+      let prefix = options.prefix[0] === '/' ? options.prefix : '/' + options.prefix;
 
       // if thre prefix failed to match, set shouldProxy to false
       if ((reqUrl.pathname || '').indexOf(prefix) !== 0) {
@@ -140,21 +138,20 @@ function buildResultingMiddleware (host, options, sharedStream) {
       }
     }
 
-
     if (typeof options.request.prepend === 'string') {
       proxyUrl.pathname = (/^\//.test(options.request.prepend) ? options.request.prepend : '/' + options.request.prepend) + (/^\//.test(proxyUrl.pathname) ? proxyUrl.pathname : '/' + proxyUrl.pathname);
     }
 
     // if there are restricts applied, and we havent failed out yet
     if (options.restrict && shouldProxy) {
-      shouldProxy = helpers.matchesRestriction(req,options.restrict);
+      shouldProxy = helpers.matchesRestriction(req, options.restrict);
     }
 
     // if the current route isn't greenlit for the passthrough, bail out
     if (!shouldProxy) { return next(); }
 
-    var encoding = undefined;
-    //Handle Image Files
+    let encoding;
+    // Handle Image Files
     if (/jpe?g|gif|png|ico|bmp|tiff/i.test(req.url)) {
       encoding = null;
     }
@@ -165,14 +162,14 @@ function buildResultingMiddleware (host, options, sharedStream) {
 
     req.headers.host = host;
 
-    var reqOpts = {
-      url     :  URL.format(proxyUrl),
+    let reqOpts = {
+      url     : URL.format(proxyUrl),
       method  : req.method,
       form    : _.defaults(options.request.form, req.body),
-      qs      : _.defaults({},options.request.query, req.query),
+      qs      : _.defaults({}, options.request.query, req.query),
       headers : helpers.defaultHeaders(options.request.headers, req.headers),
       encoding: encoding,
-      followAllRedirects : options.request.followRedirects !== false ? true : false,
+      followAllRedirects : options.request.followRedirects !== false,
       strictSSL: options.request.strictSSL !== undefined ? options.request.strictSSL : true
     };
 
@@ -187,12 +184,11 @@ function buildResultingMiddleware (host, options, sharedStream) {
     });
 
     // header cleanup before request
-    res.removeHeader("x-powered-by");
+    res.removeHeader('x-powered-by');
 
     return async.waterfall(stream, respond(next));
-  }
+  };
 }
-
 
 ////////////////////////////////////////////////////////////
 //
@@ -204,10 +200,10 @@ function buildResultingMiddleware (host, options, sharedStream) {
 // async function to make the proxied request (fires between brefore `pre` and `post` functions)
 //
 function proxyReq (proxyObj, callback) {
-  var proxyError = proxyObjErrors(proxyObj);
+  let proxyError = proxyObjErrors(proxyObj);
   if (proxyError) { return callback(new Error(proxyError)); }
 
-  if (proxyObj.options.log) { logReqOpts(proxyObj.reqOpts) }
+  if (proxyObj.options.log) { logReqOpts(proxyObj.reqOpts); }
 
   // TESTING HELPER ONLY
   if (proxyObj.options.shortCircuit) { return callback(null, proxyObj); }
@@ -254,17 +250,15 @@ function respond (next) {
       });
     }
 
-    var proxyError = proxyObjErrors(proxyObj);
+    let proxyError = proxyObjErrors(proxyObj);
     if (proxyError) {
       return next(new Error(proxyError));
-
     } else if (!(proxyObj.result && proxyObj.result.response)) {
       return next(new Error('Proxy to ' + proxyObj.reqOpts.url + ' failed for an unkown reason'));
-
     } else {
       proxyObj.res.status(proxyObj.result.response.statusCode || 400).send(proxyObj.result.body);
     }
-  }
+  };
 }
 
 ////////////////////////////////////////////////////////////
@@ -276,8 +270,8 @@ function respond (next) {
 function proxyObjErrors (proxyObj) {
   if (!proxyObj) { return '`proxyObj` not defined'; }
 
-  var errors   = '';
-  var expected = ['req', 'req', 'reqOpts', 'options'];
+  let errors   = '';
+  let expected = ['req', 'req', 'reqOpts', 'options'];
 
   _.each(expected, function (expect, index) {
     if (!proxyObj[expect]) {
@@ -287,7 +281,6 @@ function proxyObjErrors (proxyObj) {
 
   return errors ? 'Errors found in `proxyObj`: [' + errors + ']' : false;
 }
-
 
 function logReqOpts (reqOpts) {
   reqOpts = reqOpts || {};
@@ -303,7 +296,6 @@ function logReqOpts (reqOpts) {
   console.log('\n=====    Form     =====\n'.yellow);
   console.log(JSON.stringify(reqOpts.form || {}, null, '  ') + '\n');
 }
-
 
 function logResponse (response, body) {
   response = response || {};

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "scripts": {
     "test": "mocha",
-    "coverage": "istanbul cover _mocha --report lcovonly -- -R spec"
+    "coverage": "istanbul cover _mocha --report html -- -R spec "
   },
   "licenses": [
     {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "proxy-express",
   "author": "John Hofrichter <https://github.com/johnhof>",
   "description": "Request proxying middleware for express",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "repository": "git://github.com/johnhof/proxy-express",
   "main": "lib/proxy.js",
   "keywords": [
@@ -13,7 +13,7 @@
     "passthrough"
   ],
   "engines": {
-    "node": ">=0.8.0"
+    "node": ">=4.4.0"
   },
   "dependencies": {
     "async": "^0.9.x",
@@ -22,7 +22,8 @@
     "colors": "~1.0.3"
   },
   "scripts": {
-    "test": "mocha --timeout 50000"
+    "test": "mocha",
+    "coverage": "istanbul cover _mocha --report lcovonly -- -R spec"
   },
   "licenses": [
     {
@@ -34,7 +35,8 @@
     "body-parser": "^1.12.0",
     "chai": "1.10.x",
     "express": "^4.12.x",
-    "mocha": "1.21.x",
+    "istanbul": "^0.4.2",
+    "mocha": "2.4.x",
     "qs": "^2.3.3",
     "should": "1.1.x",
     "supertest": "^0.15.0",

--- a/test/core_integration_tests.js
+++ b/test/core_integration_tests.js
@@ -1,8 +1,10 @@
-var superTest  = require('supertest');
-var express    = require('express');
-var proxy      = require('../lib/proxy');
-var mocha      = require('mocha');
-var expect     = require('chai').expect;
+'use strict';
+
+const superTest  = require('supertest');
+const express    = require('express');
+const proxy      = require('../lib/proxy');
+const mocha      = require('mocha');
+const expect     = require('chai').expect;
 
 ////////////////////////////////////////////////////////////
 //
@@ -10,11 +12,10 @@ var expect     = require('chai').expect;
 //
 ////////////////////////////////////////////////////////////
 
-
 describe('Core Integration Tests', function () {
   describe('Smoke test', function () {
     it('should make a basic request to github', function (done) {
-      var server = express();
+      let server = express();
 
       server.use(proxy('api.github.com', {
         prefix  : 'github',
@@ -29,6 +30,6 @@ describe('Core Integration Tests', function () {
       }));
 
       superTest(server).get('/github').expect(200).end(done);
-    })
+    });
   });
 });

--- a/test/core_unit_tests.js
+++ b/test/core_unit_tests.js
@@ -1,21 +1,23 @@
-var superTest  = require('supertest');
-var request    = require('request');
-var express    = require('express');
-var bodyParser = require('body-parser');
-var proxy      = require('../lib/proxy');
-var mocha      = require('mocha');
-var expect     = require('chai').expect;
-var _          = require('lodash');
-var URL        = require('url');
-var QS         = require('qs');
+'use strict';
+
+const superTest  = require('supertest');
+const request    = require('request');
+const express    = require('express');
+const bodyParser = require('body-parser');
+const proxy      = require('../lib/proxy');
+const mocha      = require('mocha');
+const expect     = require('chai').expect;
+const _          = require('lodash');
+const URL        = require('url');
+const QS         = require('qs');
 
 // test configurations
-var protocol    = 'https';
-var host        = 'api.github.com';
-var prefix      = '/github';
-var defaultPath = '/';
-var ua          = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.8; rv:24.0) Gecko/20100101 Firefox/24.0';
-var language    = 'en-US,en;q=0.8';
+const protocol    = 'https';
+const host        = 'api.github.com';
+const prefix      = '/github';
+const defaultPath = '/';
+const ua          = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.8; rv:24.0) Gecko/20100101 Firefox/24.0';
+const language    = 'en-US,en;q=0.8';
 
 
 ////////////////////////////////////////////////////////////
@@ -53,18 +55,18 @@ function testProxyConfig (options, finalCb) {
   };
 
   // build the server
-  var server = express();
+  let server = express();
   server.use(bodyParser.json());
   server.use(proxy(host, options.config));
 
   // make a simple request to trigger pre requet middleware
-  var testObj = superTest(server);
+  let testObj = superTest(server);
 
   // set the method and path
   testObj = testObj[options.request.method](options.config.prefix + (options.request.path || defaultPath) + '?' + QS.stringify(options.request.query));
 
   // set supertest request form
-  if (options.request.method != 'get') {
+  if (options.request.method !== 'get') {
     testObj = testObj.send(options.request.form);
   }
 
@@ -76,10 +78,10 @@ function testProxyConfig (options, finalCb) {
   testObj.end(finalCb);
 }
 
-//add string prototype to simplify url matching
+// add string prototype to simplify url matching
 String.prototype.toUrl = function () {
   return URL.parse(this.toString(), true);
-}
+};
 
 ////////////////////////////////////////////////////////////
 //
@@ -87,11 +89,8 @@ String.prototype.toUrl = function () {
 //
 ////////////////////////////////////////////////////////////
 
-
 describe('Core Unit Tests', function () {
   describe('Config Options', function () {
-
-
     // Prefix
     //
     describe('.prefix', function () {
@@ -100,7 +99,7 @@ describe('Core Unit Tests', function () {
           config : { prefix : prefix },
           result : function testHook (proxyObj) {
             // make sure the result is the default path without the prefix
-            var path = proxyObj.reqOpts.url.toUrl().pathname;
+            let path = proxyObj.reqOpts.url.toUrl().pathname;
             expect(path).to.equal(defaultPath);
             return done();
           }
@@ -108,12 +107,11 @@ describe('Core Unit Tests', function () {
       });
     });
 
-
     // Restrict
     //
     describe('.restrict', function () {
       function testRestrict (settings, callback) {
-        var handledByProxy = false;
+        let handledByProxy = false;
         testProxyConfig({
           request : {
             path : settings.path
@@ -124,7 +122,7 @@ describe('Core Unit Tests', function () {
             pre      : function (proxyObj, callback) {
               handledByProxy = true;
               return callback();
-            },
+            }
           }
         }, function () {
           return callback(handledByProxy);
@@ -217,12 +215,9 @@ describe('Core Unit Tests', function () {
       });
     });
 
-
     // request
     //
     describe('.request', function () {
-
-
       // Force Https
       //
       describe('.forceHttps', function () {
@@ -242,12 +237,11 @@ describe('Core Unit Tests', function () {
         });
       });
 
-
       // Prepend Request
       //
       describe('.prepend', function () {
         it('should prepend `/foo/bar/test` to the request', function (done) {
-          var prepend = 'foo/bar/test';
+          let prepend = 'foo/bar/test';
           testProxyConfig({
             request : {
               path: '/biz'
@@ -264,7 +258,6 @@ describe('Core Unit Tests', function () {
           });
         });
       });
-
 
       // Follow Redirects
       //
@@ -293,12 +286,11 @@ describe('Core Unit Tests', function () {
         });
       });
 
-
       // Request Headers
       //
       describe('.headers', function () {
-        var overrideUa     = 'test';
-        var requestHeaders = {
+        let overrideUa     = 'test';
+        let requestHeaders = {
           'User-Agent'      : ua,
           'accept-language' : language
         };
@@ -346,8 +338,8 @@ describe('Core Unit Tests', function () {
       // Request Query
       //
       describe('.query', function () {
-        var overrideQuery = { test: 'foo' };
-        var requestQuery  = {
+        let overrideQuery = { test: 'foo' };
+        let requestQuery  = {
           test : 'bar',
           biz  : 'baz'
         };
@@ -387,12 +379,11 @@ describe('Core Unit Tests', function () {
         });
       });
 
-
       // Request Form
       //
       describe('.form', function () {
-        var overrideForm = { test: 'foo' };
-        var requestForm  = {
+        let overrideForm = { test: 'foo' };
+        let requestForm  = {
           test : 'bar',
           biz  : 'baz'
         };
@@ -435,12 +426,11 @@ describe('Core Unit Tests', function () {
       });
     });
 
-
     // Pre
     //
     describe('.pre', function () {
       it('should accept a single functions', function (done) {
-        var funcCount = 0;
+        let funcCount = 0;
         testProxyConfig({
           config : {
             pre : function (proxyObj, callback) {
@@ -456,7 +446,7 @@ describe('Core Unit Tests', function () {
       });
 
       it('should accept an array of functions', function (done) {
-        var funcCount = 0;
+        let funcCount = 0;
         function funcStepper (proxyObj, callback) {
           funcCount++;
           return callback();
@@ -478,7 +468,6 @@ describe('Core Unit Tests', function () {
       });
     });
 
-
     // Post
     //
     describe('.post', function () {
@@ -495,7 +484,7 @@ describe('Core Unit Tests', function () {
       });
 
       it('should accept an array of functions', function (done) {
-        var funcCount = 0;
+        let funcCount = 0;
         function funcStepper (proxyObj, callback) {
           funcCount++;
           return callback();

--- a/test/helpers_unit_tests.js
+++ b/test/helpers_unit_tests.js
@@ -1,7 +1,9 @@
-var helpers = require('../lib/helpers');
-var mocha   = require('mocha');
-var expect  = require('chai').expect;
-var _       = require('lodash');
+'use strict';
+
+const helpers = require('../lib/helpers');
+const mocha   = require('mocha');
+const expect  = require('chai').expect;
+const _       = require('lodash');
 
 ////////////////////////////////////////////////////////////
 //
@@ -9,14 +11,13 @@ var _       = require('lodash');
 //
 ////////////////////////////////////////////////////////////
 
-
 describe('Helpers Unit Tests', function () {
 
   // Default Headers
   //
   describe('defaultHeaders', function () {
-    var success = 'OK';
-    var result  = helpers.defaultHeaders({
+    let success = 'OK';
+    let result  = helpers.defaultHeaders({
       foo : success,
       bar : undefined
     }, {
@@ -41,93 +42,87 @@ describe('Helpers Unit Tests', function () {
   // Matches Restriction
   //
   describe('matchesRestriction', function () {
-    var regExp = /.+\/bar/;
-    var string = 'foo';
+    let regExp = /.+\/bar/;
+    let string = 'foo';
 
     it('should return true for path matching regex', function () {
-      expect(helpers.matchesRestriction({url:'/foo/bar'}, regExp)).to.equal(true);
+      expect(helpers.matchesRestriction({url: '/foo/bar'}, regExp)).to.equal(true);
     });
 
     it('should return false for path failing to match regexp', function () {
-      expect(helpers.matchesRestriction({url:'/bar/foo'}, regExp)).to.equal(false);
+      expect(helpers.matchesRestriction({url: '/bar/foo'}, regExp)).to.equal(false);
     });
 
     it('should return true for path containing string', function () {
-      expect(helpers.matchesRestriction({url:'/foo/bar'}, string)).to.equal(true);
+      expect(helpers.matchesRestriction({url: '/foo/bar'}, string)).to.equal(true);
     });
 
     it('should return false for path containing string', function () {
-      expect(helpers.matchesRestriction({url:'/bar/biz'}, string)).to.equal(false);
+      expect(helpers.matchesRestriction({url: '/bar/biz'}, string)).to.equal(false);
     });
 
     describe('with a filter function', function () {
-      describe('returning boolean', function(){
-        it('should return false for a function that returns false', function() {
-          expect(helpers.matchesRestriction({url:'/bar/biz'}, function(){ return false; })).to.equal(false);
+      describe('returning boolean', function () {
+        it('should return false for a function that returns false', function () {
+          expect(helpers.matchesRestriction({url: '/bar/biz'}, () => false)).to.equal(false);
         });
 
-        it('should return true for a function that returns true', function() {
-          expect(helpers.matchesRestriction({url:'/bar/biz'}, function(){ return true; })).to.equal(true);
+        it('should return true for a function that returns true', function () {
+          expect(helpers.matchesRestriction({url: '/bar/biz'}, () => true)).to.equal(true);
         });
       });
 
-      describe('returning a string', function(){
-        it('should return true for a path containing a string', function() {
-          expect(helpers.matchesRestriction({url:'/foo/bar'}, function(){ return string; })).to.equal(true);
+      describe('returning a string', function () {
+        it('should return true for a path containing a string', function () {
+          expect(helpers.matchesRestriction({url: '/foo/bar'}, () => string)).to.equal(true);
         });
 
         it('should return false for a path containing string', function () {
-          expect(helpers.matchesRestriction({url:'/bar/biz'}, function(){ return string; })).to.equal(false);
+          expect(helpers.matchesRestriction({url: '/bar/biz'}, () => string)).to.equal(false);
         });
       });
 
-      describe('returning a regexp', function(){
+      describe('returning a regexp', function () {
         it('should return true for path matching regex', function () {
-          expect(helpers.matchesRestriction({url:'/foo/bar'}, function(){ return regExp; })).to.equal(true);
+          expect(helpers.matchesRestriction({url: '/foo/bar'}, () => regExp)).to.equal(true);
         });
 
         it('should return false for path failing to match regexp', function () {
-          expect(helpers.matchesRestriction({url:'/bar/foo'}, function(){ return regExp; })).to.equal(false);
+          expect(helpers.matchesRestriction({url: '/bar/foo'}, () => regExp)).to.equal(false);
         });
       });
 
-      describe('returning a function', function() {
+      describe('returning a function', function () {
         describe('returning boolean', function () {
           it('should return false for a function that returns false', function () {
-            expect(helpers.matchesRestriction({url: '/bar/biz'}, function () {
-              return _.constant(false);
-            })).to.equal(false);
+            expect(helpers.matchesRestriction({url: '/bar/biz'}, () => _.constant(false))).to.equal(false);
           });
 
           it('should return true for a function that returns true', function () {
-            expect(helpers.matchesRestriction({url: '/bar/biz'}, function () {
-              return _.constant(true);
-            })).to.equal(true);
+            expect(helpers.matchesRestriction({url: '/bar/biz'}, () => _.constant(true))).to.equal(true);
           });
         });
       });
 
       describe('with an array', function () {
-        it('should return false if all array values return false', function() {
+        it('should return false if all array values return false', function () {
           expect(helpers.matchesRestriction({url: '/bar/biz'}, [
             regExp,
             string,
             false,
-            function () { return _.constant(false); }
+            () => _.constant(false)
           ])).to.equal(false);
         });
 
-        it('should return true if one array value returns true', function() {
+        it('should return true if one array value returns true', function () {
           expect(helpers.matchesRestriction({url: '/bar/biz'}, [
             regExp,
             string,
             false,
-            function () { return _.constant(true); }
+            () => _.constant(true)
           ])).to.equal(true);
         });
-
       });
-
     });
   });
 });

--- a/test/regression_tests.js
+++ b/test/regression_tests.js
@@ -1,8 +1,10 @@
-var superTest  = require('supertest');
-var express    = require('express');
-var proxy      = require('../lib/proxy');
-var mocha      = require('mocha');
-var expect     = require('chai').expect;
+'use strict';
+
+const superTest  = require('supertest');
+const express    = require('express');
+const proxy      = require('../lib/proxy');
+const mocha      = require('mocha');
+const expect     = require('chai').expect;
 
 ////////////////////////////////////////////////////////////
 //
@@ -14,7 +16,7 @@ var expect     = require('chai').expect;
 describe('Regression Tests', function () {
   describe('Status Code', function () {
     it('should properly proxy non 200 responses', function (done) {
-      var server = express();
+      let server = express();
 
       server.use(proxy('api.github.com', {
         prefix  : 'github',
@@ -29,6 +31,6 @@ describe('Regression Tests', function () {
       }));
 
       superTest(server).get('/github/four/oh/four').expect(404).end(done);
-    })
+    });
   });
 });


### PR DESCRIPTION
Resolves #28 

As I mentioned in the issue, I used a light touch when converting to 4.  I only updated `var` requires -> `const` all other vars became `let`.  I only fat arrowed a couple obvious ones

Most of the changes are tiny style fixes, Im running a linter locally (semistandard) while I didnt convert all of the code to it, I cleaned up function signatures / white space / missing semicolon issues.  It makes the codebase look a tiny bit nicer.
# Bonus

I added an additional script for code coverage, run it by executing `npm run coverage`.

```
=============================== Coverage summary ===============================
Statements   : 77.08% ( 111/144 )
Branches     : 60.5% ( 72/119 )
Functions    : 89.47% ( 17/19 )
Lines        : 80% ( 108/135 )
================================================================================
```

Yikes! So I will be adding Unit tests as I have free time.  Let me know if you want anything changed. Once I get the test coverage up, I'll start updating the modules.
