### PR TITLE
proxy redirect option setting is incorrect

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -161,6 +161,7 @@ function buildResultingMiddleware (host, options, sharedStream) {
       qs      : _.defaults({}, options.request.query, req.query),
       headers : helpers.defaultHeaders(options.request.headers, req.headers),
       encoding: encoding,
+      followRedirect: options.request.followRedirects !== false,
       followAllRedirects : options.request.followRedirects !== false,
       strictSSL: options.request.strictSSL !== undefined ? options.request.strictSSL : true
     };


### PR DESCRIPTION
when proxy server receive 302 redirect header, the proxy.js set the options incorrect. according the doc https://yarnpkg.com/zh-Hans/package/request, also, I had reappeared from my practical action.