### PR TITLE
fix bug when use proxy-express as a reverse proxy server

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,12 +77,27 @@ Forward all requests to the host specified. Only requests made with the prefix i
   // [METHOD] /foo/users => proxied to [METHOD] //www.foo.com/users
 ```
 
+## Proxy To Virtual host Website 
+
+Virtual host refers to HTTP header `host`. If proxy target is a virtual host website, set the header `host`'s value to  the website domain name
+
+```javascript
+  server.use(proxy('www.foo.com', {
+    request : {
+      headers  : {
+        'host' : 'www.foo.com',
+      }
+    }
+  }));
+```
+
+
 ## Proxy With Configuration
 
 Allows complex configuration. More details in the [configuration section](#configuration-options)
 
 ```javascript
-  server.use(proxy('ww.foo.com', {
+  server.use(proxy('www.foo.com', {
     prefix  : 'foo',
     request : {
       forceHttps : true,

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -152,7 +152,7 @@ function buildResultingMiddleware (host, options, sharedStream) {
     // compile the request object used for the `request` module call
     //
 
-    req.headers.host = host;
+    //req.headers.host = host;
 
     let reqOpts = {
       url     : URL.format(proxyUrl),

--- a/test/core_integration_tests.js
+++ b/test/core_integration_tests.js
@@ -24,6 +24,7 @@ describe('Core Integration Tests', function () {
           strictSSL  : false,
           headers    : {
             'User-Agent' : 'Mozilla/5.0 (X11; Linux i686 (x86_64)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.71 Safari/537.36',
+            'host' : 'api.github.com',
             Authorization : require('./github_auth_header')
           }
         },
@@ -41,6 +42,7 @@ describe('Core Integration Tests', function () {
         request : {
           headers    : {
             'User-Agent' : 'Mozilla/5.0 (X11; Linux i686 (x86_64)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.71 Safari/537.36',
+            'host' : 'i.imgur.com',
           }
         }
       }));

--- a/test/regression_tests.js
+++ b/test/regression_tests.js
@@ -25,6 +25,7 @@ describe('Regression Tests', function () {
           strictSSL  : false,
           headers    : {
             'User-Agent' : 'Mozilla/5.0 (X11; Linux i686 (x86_64)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.71 Safari/537.36',
+            'host' : 'api.github.com',
             Authorization : require('./github_auth_header')
           }
         }


### PR DESCRIPTION
     
When I use proxy-express as a reverse proxy server, if the target server will need to use the 'host' value in HTTP header.  It usually refers to the request host, not the target server host. for example:
If I want to use www.b.com proxy pass to www.a.com server, then actually my server host name is www.b.com, but not www.a.com. If not, one problem is that: 
when user visit to www.b.com, and the server www.a.com produces a 302 redirect, the redirect location value in HTTP header is www.a.com/path. The value comes from the host value setting in HTTP header. But the browser can't not redirect to www.a.com/path.
      In other proxy server case,  like nginx, when we use nginx as a reverse server , we usually config like this:
	location ^~ /
        { 
            proxy_pass http://192.168.1.112:8680/;
            proxy_set_header Host $host;
            proxy_set_header Port $server_port;
        }
     It means that I can pass the font host value to the target server.

But I found that, proxy.js set the host value directly use that target server host around line 155, just  like:

```
req.headers.host = host;
```
     
   I thought a lot why you set this value, I just find one situation that your target server is a virtual host website, We need to set the host as the target server host, then we can use another domain to visit. In other case I thought it is better not to change the host value.
      Pls let me know more reasons about setting the host value, or maybe we can add an usege example to indicate the web-hosting's case.